### PR TITLE
Convert homepage to PHP login handler

### DIFF
--- a/docs/users_table.sql
+++ b/docs/users_table.sql
@@ -1,0 +1,12 @@
+-- Table structure for storing user credentials and login metadata
+CREATE TABLE IF NOT EXISTS `users` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `email` VARCHAR(255) NOT NULL,
+  `password_hash` VARCHAR(255) NOT NULL,
+  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `last_login_at` DATETIME DEFAULT NULL,
+  `last_login_ip` VARCHAR(45) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `users_email_unique` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary
- convert the landing page into a PHP script that validates login submissions, protects with CSRF tokens and handles storage via PDO
- surface form feedback, set proper input attributes, and post back to the secure handler on the homepage
- document the `users` table structure needed for hashed credentials and login metadata

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ccdbd404988332a7f0c9435688e3e6