### PR TITLE
Activate PHP user registration form

### DIFF
--- a/Version_index.html
+++ b/Version_index.html
@@ -405,7 +405,7 @@
           <li class="mt-0.5 w-full">
             <a
               class="py-2.7 text-sm ease-nav-brand my-0 mx-4 flex items-center whitespace-nowrap px-4 transition-colors"
-              href="./pages/sign-up.html">
+              href="./pages/sign-up.php">
               <div
                 class="shadow-soft-2xl mr-2 flex h-8 w-8 items-center justify-center rounded-lg bg-white bg-center stroke-0 text-center xl:p-2.5">
                 <svg

--- a/index.php
+++ b/index.php
@@ -192,7 +192,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                   <li>
                     <a
                       class="block px-4 py-2 mr-2 font-normal transition-all lg-max:opacity-0 duration-250 ease-soft-in-out text-sm text-slate-700 lg:px-2"
-                      href="../pages/sign-up.html">
+                      href="../pages/sign-up.php">
                       <i class="mr-1 fas fa-user-circle opacity-60"></i>
                       Sign Up
                     </a>
@@ -309,7 +309,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <p class="mx-auto mb-6 leading-normal text-sm">
                       Don't have an account?
                       <a
-                        href="../pages/sign-up.html"
+                        href="../pages/sign-up.php"
                         class="relative z-10 font-semibold text-transparent bg-gradient-to-tl from-blue-600 to-cyan-400 bg-clip-text"
                         >Sign up</a
                       >

--- a/pages/billing.html
+++ b/pages/billing.html
@@ -407,7 +407,7 @@
           <li class="mt-0.5 w-full">
             <a
               class="py-2.7 text-sm ease-nav-brand my-0 mx-4 flex items-center whitespace-nowrap px-4 transition-colors"
-              href="../pages/sign-up.html">
+              href="../pages/sign-up.php">
               <div
                 class="shadow-soft-2xl mr-2 flex h-8 w-8 items-center justify-center rounded-lg bg-white bg-center stroke-0 text-center xl:p-2.5">
                 <svg

--- a/pages/dashboard.html
+++ b/pages/dashboard.html
@@ -406,7 +406,7 @@
           <li class="mt-0.5 w-full">
             <a
               class="py-2.7 text-sm ease-nav-brand my-0 mx-4 flex items-center whitespace-nowrap px-4 transition-colors"
-              href="../pages/sign-up.html">
+              href="../pages/sign-up.php">
               <div
                 class="shadow-soft-2xl mr-2 flex h-8 w-8 items-center justify-center rounded-lg bg-white bg-center stroke-0 text-center xl:p-2.5">
                 <svg

--- a/pages/profile.html
+++ b/pages/profile.html
@@ -406,7 +406,7 @@
           <li class="mt-0.5 w-full">
             <a
               class="py-2.7 text-sm ease-nav-brand my-0 mx-4 flex items-center whitespace-nowrap px-4 transition-colors"
-              href="../pages/sign-up.html">
+              href="../pages/sign-up.php">
               <div
                 class="shadow-soft-2xl mr-2 flex h-8 w-8 items-center justify-center rounded-lg bg-white bg-center stroke-0 text-center xl:p-2.5">
                 <svg

--- a/pages/rtl.html
+++ b/pages/rtl.html
@@ -407,7 +407,7 @@
           <li class="mt-0.5 w-full">
             <a
               class="py-2.7 text-sm ease-nav-brand my-0 mx-4 flex items-center whitespace-nowrap px-4 transition-colors"
-              href="../pages/sign-up.html">
+              href="../pages/sign-up.php">
               <div
                 class="shadow-soft-2xl ml-2 flex h-8 w-8 items-center justify-center rounded-lg bg-white bg-center stroke-0 text-center xl:p-2.5">
                 <svg

--- a/pages/sign-in.html
+++ b/pages/sign-in.html
@@ -108,7 +108,7 @@
                   <li>
                     <a
                       class="block px-4 py-2 mr-2 font-normal transition-all lg-max:opacity-0 duration-250 ease-soft-in-out text-sm text-slate-700 lg:px-2"
-                      href="../pages/sign-up.html">
+                      href="../pages/sign-up.php">
                       <i class="mr-1 fas fa-user-circle opacity-60"></i>
                       Sign Up
                     </a>
@@ -205,7 +205,7 @@
                     <p class="mx-auto mb-6 leading-normal text-sm">
                       Don't have an account?
                       <a
-                        href="../pages/sign-up.html"
+                        href="../pages/sign-up.php"
                         class="relative z-10 font-semibold text-transparent bg-gradient-to-tl from-blue-600 to-cyan-400 bg-clip-text"
                         >Sign up</a
                       >

--- a/pages/tables.html
+++ b/pages/tables.html
@@ -212,7 +212,7 @@
           </li>
 
           <li class="mt-0.5 w-full">
-            <a class="py-2.7 text-sm ease-nav-brand my-0 mx-4 flex items-center whitespace-nowrap px-4 transition-colors" href="../pages/sign-up.html">
+            <a class="py-2.7 text-sm ease-nav-brand my-0 mx-4 flex items-center whitespace-nowrap px-4 transition-colors" href="../pages/sign-up.php">
               <div class="shadow-soft-2xl mr-2 flex h-8 w-8 items-center justify-center rounded-lg bg-white bg-center stroke-0 text-center xl:p-2.5">
                 <svg width="12px" height="20px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                   <title>spaceship</title>

--- a/pages/virtual-reality.html
+++ b/pages/virtual-reality.html
@@ -342,7 +342,7 @@
             </li>
 
             <li class="mt-0.5 w-full">
-              <a class="py-2.7 text-sm ease-nav-brand my-0 mx-4 flex items-center whitespace-nowrap px-4 transition-colors" href="../pages/sign-up.html">
+              <a class="py-2.7 text-sm ease-nav-brand my-0 mx-4 flex items-center whitespace-nowrap px-4 transition-colors" href="../pages/sign-up.php">
                 <div class="icon text-icon shadow-soft-2xl mr-2 flex h-8 w-8 items-center justify-center rounded-lg bg-white bg-center stroke-0 text-center xl:p-2.5">
                   <svg width="12px" height="20px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                     <title>spaceship</title>


### PR DESCRIPTION
## Summary
- convert the sign-up page into a PHP script that handles CSRF-protected user creation with validation and database persistence
- render contextual success and error alerts while preserving form inputs on validation failures
- point existing navigation links to the new PHP registration route throughout the dashboard

## Testing
- php -l pages/sign-up.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ccf0120d088332873c4ed44d185fe8